### PR TITLE
Fix line endings on POLICY.md to always CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+POLICY.md text eol=crlf


### PR DESCRIPTION
This avoids the SHA256 hash changing depending on host OS. Choosing CRLF as it's easier to process CRLF on Linux than LF on Windows.
