### PR TITLE
Authenticate patricklodder's key and sign policy

### DIFF
--- a/keys/patricklodder.txt.asc
+++ b/keys/patricklodder.txt.asc
@@ -1,0 +1,34 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+The following is my public key for use in the 3/5 multisig
+wallet that is described in the file POLICY.md
+
+POLICY.md sha256sum: a1fd0f7c92a52a519ac922a2285c8add27ae370c4506aefd2143a1697d2c4b2e
+
+Patrick Lodder, 12/28/2022
+
+{
+   "isvalid": true,
+   "address": "DDVLGvC3yZMjRZ3hjVWpX1nW6dFN1sqa1a",
+   "scriptPubKey": "76a9145b94ca94a383d95f509e4e43906d4c0fcbd5482a88ac",
+   "ismine": true,
+   "iswatchonly": false,
+   "isscript": false,
+   "pubkey": "02e8091f9e22512cce2539fa24876da79e9a6af30fd5fcb861b652543f4a84d497",
+   "iscompressed": true,
+   "account": "account",
+   "timestamp": 1671842021,
+}
+
+-----BEGIN PGP SIGNATURE-----
+
+iQEzBAEBCAAdFiEE3G70qL+fGx5N4e5SLTo0W5jQ3B8FAmOsvnoACgkQLTo0W5jQ
+3B9tbQf+I60m2NDM/tQ65xNKyExdvmbv3/jTXNLePNkc541by9X7bQaLWejPxWnM
+3+rn0ASCbFSqb1nJv3v86+2nlRGeMXKjF4BV4U2Rb5Fe/RBs6Amt1B+iXMjHA5zS
+7nKv16Ud/R89r5K8a+TBVvB4tctxRh9BnvTi9SLckvCSzIxqJilVkJKMDrRXcqj+
+LKfdx6qNhi0TXhEHESLjV9MwvHRd5zrE1RbOcJJMFgBYV237YL22g8eH3jq6ZhVD
+cAW+XYCAY6kj8LVa6yxBMkvCGvNni1XQoUxwSCn+qBEgfA5q9hntJLPhz/QitSpS
+Miuh0iz/AR2ljAFQFIuS7sn30bG34Q==
+=y3CT
+-----END PGP SIGNATURE-----


### PR DESCRIPTION
- signs public key `02e8091f9e22512cce2539fa24876da79e9a6af30fd5fcb861b652543f4a84d497`
- signs policy.md with hash `a1fd0f7c92a52a519ac922a2285c8add27ae370c4506aefd2143a1697d2c4b2e`

Signatures have been performed with my known gpg key from Dogecoin Core's release process, find it here: https://github.com/dogecoin/dogecoin/blob/master/contrib/gitian-keys/patricklodder-key.pgp

I'm signing both the key and the policy in one go so that these are linked together: the key is only for this policy. Anyone can hold me to that agreement. If there is a change to the policy, a new key will be required.
